### PR TITLE
fix use of wrong variable for error string

### DIFF
--- a/model.c
+++ b/model.c
@@ -125,7 +125,7 @@ scald_report_error(struct blob_buf *buf, const char *name, int code)
 
 	c = blobmsg_open_table(buf, name);
 	blobmsg_add_u32(buf, "code", code);
-	blobmsg_add_string(buf, "message", error_strings[code]);
+	blobmsg_add_string(buf, "message", str);
 	blobmsg_close_table(&b, c);
 }
 


### PR DESCRIPTION
The change resolves this compile warning:

[ 25%] Building C object CMakeFiles/scald.dir/model.c.o
/opt/dev/scal/model.c: In function 'scald_report_error':
/opt/dev/scal/model.c:116:14: error: variable 'str' set but not used [-Werror=unused-but-set-variable]
  const char *str = NULL;

Signed-off-by: Denis Osvald <denis.osvald@sartura.hr>
Reviewed-by: Luka Perkov <luka.perkov@sartura.hr>