### PR TITLE
fix string allocation size miscalculation

### DIFF
--- a/model.c
+++ b/model.c
@@ -447,7 +447,7 @@ scald_model_new(const char *name)
 	char *name_buf;
 	int ret;
 
-	m = calloc_a(sizeof(*m), &name_buf, 4 /* scald. */ + strlen(name) + 1);
+	m = calloc_a(sizeof(*m), &name_buf, 6 /* scald. */ + strlen(name) + 1);
 	if (!m)
 		return NULL;
 


### PR DESCRIPTION
The char buffer for an ubus object's size must add the prefix "scald.",
which is 6 characters long, not 4. Fix the miscalculation.

Signed-off-by: Denis Osvald <denis.osvald@sartura.hr>